### PR TITLE
feat: added support for the Telegram /start comment

### DIFF
--- a/src/bot/handlers/webhook-handler.js
+++ b/src/bot/handlers/webhook-handler.js
@@ -49,6 +49,15 @@ class WebhookHandler {
       case "/help":
         report = reportsHandler.redirectHelp();
         return new BotavioRequestModel(data, command, report);
+      
+      case "/start":
+        /*
+          This is needed for new users that interacts with Botavio.
+          Telegram bound users to send /start in their first interaction with the Bot.
+          Botavio should understand /start the same as /help.
+        */
+        report = reportsHandler.redirectHelp();
+        return new BotavioRequestModel(data, command, report);
 
       default:
         // Handle unknown commands.


### PR DESCRIPTION
Telegram bounds the new user in it's first conversation with the Bot to send a /start to it.
Botavio should understand /start the same as /help.